### PR TITLE
Remove underline from assistant_input

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,7 +35,13 @@
             android:enabled="true"
             android:imeOptions="actionSend"
             android:focusable="true"
-            android:focusableInTouchMode="true"/>
+            android:focusableInTouchMode="true"
+            android:background="@android:color/transparent"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+        />
 
         <ProgressBar
             android:layout_width="wrap_content"


### PR DESCRIPTION
This should remove the underline on the input bar and make that component slightly more nice looking.

Also, as a side effect of removing the underline I needed to add new paddings, to which I chose 4dp horizontal and 16dp vertical, this might not look as nice on tablets depending on how android does the default padding for EditText-like elements.